### PR TITLE
Use Str::contains instead of str_contains to support PHP 7.x

### DIFF
--- a/SeedServiceProvider.php
+++ b/SeedServiceProvider.php
@@ -43,7 +43,10 @@ class SeedServiceProvider extends ServiceProvider
         $args = Request::server('argv', null);
         if (is_array($args)) {
             $command = implode(' ', $args);
-            if (Str::contains($command, $contain_options) && ($exclude_options == null || ! Str::contains($command, $exclude_options))) {
+            if (
+                Str::contains($command, $contain_options) &&
+                ($exclude_options == null || !Str::contains($command, $exclude_options))
+            ) {
                 return true;
             }
         }

--- a/SeedServiceProvider.php
+++ b/SeedServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 class SeedServiceProvider extends ServiceProvider
@@ -42,7 +43,7 @@ class SeedServiceProvider extends ServiceProvider
         $args = Request::server('argv', null);
         if (is_array($args)) {
             $command = implode(' ', $args);
-            if (str_contains($command, $contain_options) && ($exclude_options == null || !str_contains($command, $exclude_options))) {
+            if (Str::contains($command, $contain_options) && ($exclude_options == null || ! Str::contains($command, $exclude_options))) {
                 return true;
             }
         }


### PR DESCRIPTION
`str_contains` is an RFC only available in PHP 8+, while `Str::class` helper is available in PHP 7.x